### PR TITLE
upgraded civix templates

### DIFF
--- a/donotsendreportemail.civix.php
+++ b/donotsendreportemail.civix.php
@@ -7,9 +7,9 @@
  * extension.
  */
 class CRM_Donotsendreportemail_ExtensionUtil {
-  const SHORT_NAME = "donotsendreportemail";
-  const LONG_NAME = "org.civicrm.donotsendreportemail";
-  const CLASS_PREFIX = "CRM_Donotsendreportemail";
+  const SHORT_NAME = 'donotsendreportemail';
+  const LONG_NAME = 'org.civicrm.donotsendreportemail';
+  const CLASS_PREFIX = 'CRM_Donotsendreportemail';
 
   /**
    * Translate a string using the extension's domain.
@@ -24,9 +24,9 @@ class CRM_Donotsendreportemail_ExtensionUtil {
    *   Translated text.
    * @see ts
    */
-  public static function ts($text, $params = array()) {
+  public static function ts($text, $params = []): string {
     if (!array_key_exists('domain', $params)) {
-      $params['domain'] = array(self::LONG_NAME, NULL);
+      $params['domain'] = [self::LONG_NAME, NULL];
     }
     return ts($text, $params);
   }
@@ -41,7 +41,7 @@ class CRM_Donotsendreportemail_ExtensionUtil {
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
    */
-  public static function url($file = NULL) {
+  public static function url($file = NULL): string {
     if ($file === NULL) {
       return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
     }
@@ -79,273 +79,49 @@ class CRM_Donotsendreportemail_ExtensionUtil {
 
 use CRM_Donotsendreportemail_ExtensionUtil as E;
 
+function _donotsendreportemail_civix_mixin_polyfill() {
+  if (!class_exists('CRM_Extension_MixInfo')) {
+    $polyfill = __DIR__ . '/mixin/polyfill.php';
+    (require $polyfill)(E::LONG_NAME, E::SHORT_NAME, E::path());
+  }
+}
+
 /**
  * (Delegated) Implements hook_civicrm_config().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
-function _donotsendreportemail_civix_civicrm_config(&$config = NULL) {
+function _donotsendreportemail_civix_civicrm_config($config = NULL) {
   static $configured = FALSE;
   if ($configured) {
     return;
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
-
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
-  $extDir = $extRoot . 'templates';
-
-  if (is_array($template->template_dir)) {
-    array_unshift($template->template_dir, $extDir);
-  }
-  else {
-    $template->template_dir = array($extDir, $template->template_dir);
-  }
-
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
-}
-
-/**
- * (Delegated) Implements hook_civicrm_xmlMenu().
- *
- * @param $files array(string)
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
- */
-function _donotsendreportemail_civix_civicrm_xmlMenu(&$files) {
-  foreach (_donotsendreportemail_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
-    $files[] = $file;
-  }
+  _donotsendreportemail_civix_mixin_polyfill();
 }
 
 /**
  * Implements hook_civicrm_install().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
 function _donotsendreportemail_civix_civicrm_install() {
   _donotsendreportemail_civix_civicrm_config();
-  if ($upgrader = _donotsendreportemail_civix_upgrader()) {
-    $upgrader->onInstall();
-  }
-}
-
-/**
- * Implements hook_civicrm_postInstall().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
- */
-function _donotsendreportemail_civix_civicrm_postInstall() {
-  _donotsendreportemail_civix_civicrm_config();
-  if ($upgrader = _donotsendreportemail_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onPostInstall'))) {
-      $upgrader->onPostInstall();
-    }
-  }
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
- */
-function _donotsendreportemail_civix_civicrm_uninstall() {
-  _donotsendreportemail_civix_civicrm_config();
-  if ($upgrader = _donotsendreportemail_civix_upgrader()) {
-    $upgrader->onUninstall();
-  }
+  _donotsendreportemail_civix_mixin_polyfill();
 }
 
 /**
  * (Delegated) Implements hook_civicrm_enable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
-function _donotsendreportemail_civix_civicrm_enable() {
+function _donotsendreportemail_civix_civicrm_enable(): void {
   _donotsendreportemail_civix_civicrm_config();
-  if ($upgrader = _donotsendreportemail_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onEnable'))) {
-      $upgrader->onEnable();
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_disable().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
- * @return mixed
- */
-function _donotsendreportemail_civix_civicrm_disable() {
-  _donotsendreportemail_civix_civicrm_config();
-  if ($upgrader = _donotsendreportemail_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onDisable'))) {
-      $upgrader->onDisable();
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_upgrade().
- *
- * @param $op string, the type of operation being performed; 'check' or 'enqueue'
- * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
- *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
- */
-function _donotsendreportemail_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  if ($upgrader = _donotsendreportemail_civix_upgrader()) {
-    return $upgrader->onUpgrade($op, $queue);
-  }
-}
-
-/**
- * @return CRM_Donotsendreportemail_Upgrader
- */
-function _donotsendreportemail_civix_upgrader() {
-  if (!file_exists(__DIR__ . '/CRM/Donotsendreportemail/Upgrader.php')) {
-    return NULL;
-  }
-  else {
-    return CRM_Donotsendreportemail_Upgrader_Base::instance();
-  }
-}
-
-/**
- * Search directory tree for files which match a glob pattern
- *
- * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
- *
- * @param $dir string, base dir
- * @param $pattern string, glob pattern, eg "*.txt"
- * @return array(string)
- */
-function _donotsendreportemail_civix_find_files($dir, $pattern) {
-  if (is_callable(array('CRM_Utils_File', 'findFiles'))) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
-
-  $todos = array($dir);
-  $result = array();
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_donotsendreportemail_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
-        }
-        elseif (is_dir($path)) {
-          $todos[] = $path;
-        }
-      }
-      closedir($dh);
-    }
-  }
-  return $result;
-}
-/**
- * (Delegated) Implements hook_civicrm_managed().
- *
- * Find any *.mgd.php files, merge their content, and return.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
- */
-function _donotsendreportemail_civix_civicrm_managed(&$entities) {
-  $mgdFiles = _donotsendreportemail_civix_find_files(__DIR__, '*.mgd.php');
-  foreach ($mgdFiles as $file) {
-    $es = include $file;
-    foreach ($es as $e) {
-      if (empty($e['module'])) {
-        $e['module'] = E::LONG_NAME;
-      }
-      $entities[] = $e;
-      if (empty($e['params']['version'])) {
-        $e['params']['version'] = '3';
-      }
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_caseTypes().
- *
- * Find any and return any files matching "xml/case/*.xml"
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
- */
-function _donotsendreportemail_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
-    return;
-  }
-
-  foreach (_donotsendreportemail_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
-    $name = preg_replace('/\.xml$/', '', basename($file));
-    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
-      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      CRM_Core_Error::fatal($errorMessage);
-      // throw new CRM_Core_Exception($errorMessage);
-    }
-    $caseTypes[$name] = array(
-      'module' => E::LONG_NAME,
-      'name' => $name,
-      'file' => $file,
-    );
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_angularModules().
- *
- * Find any and return any files matching "ang/*.ang.php"
- *
- * Note: This hook only runs in CiviCRM 4.5+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
- */
-function _donotsendreportemail_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
-    return;
-  }
-
-  $files = _donotsendreportemail_civix_glob(__DIR__ . '/ang/*.ang.php');
-  foreach ($files as $file) {
-    $name = preg_replace(':\.ang\.php$:', '', basename($file));
-    $module = include $file;
-    if (empty($module['ext'])) {
-      $module['ext'] = E::LONG_NAME;
-    }
-    $angularModules[$name] = $module;
-  }
-}
-
-/**
- * Glob wrapper which is guaranteed to return an array.
- *
- * The documentation for glob() says, "On some systems it is impossible to
- * distinguish between empty match and an error." Anecdotally, the return
- * result for an empty match is sometimes array() and sometimes FALSE.
- * This wrapper provides consistency.
- *
- * @link http://php.net/glob
- * @param string $pattern
- * @return array, possibly empty
- */
-function _donotsendreportemail_civix_glob($pattern) {
-  $result = glob($pattern);
-  return is_array($result) ? $result : array();
+  _donotsendreportemail_civix_mixin_polyfill();
 }
 
 /**
@@ -356,16 +132,18 @@ function _donotsendreportemail_civix_glob($pattern) {
  *    'Mailing', or 'Administer/System Settings'
  * @param array $item - the item to insert (parent/child attributes will be
  *    filled for you)
+ *
+ * @return bool
  */
 function _donotsendreportemail_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
   if (empty($path)) {
-    $menu[] = array(
-      'attributes' => array_merge(array(
-        'label'      => CRM_Utils_Array::value('name', $item),
-        'active'     => 1,
-      ), $item),
-    );
+    $menu[] = [
+      'attributes' => array_merge([
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
+      ], $item),
+    ];
     return TRUE;
   }
   else {
@@ -376,9 +154,9 @@ function _donotsendreportemail_civix_insert_navigation_menu(&$menu, $path, $item
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
         if (!isset($entry['child'])) {
-          $entry['child'] = array();
+          $entry['child'] = [];
         }
-        $found = _donotsendreportemail_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
+        $found = _donotsendreportemail_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
       }
     }
     return $found;
@@ -389,7 +167,7 @@ function _donotsendreportemail_civix_insert_navigation_menu(&$menu, $path, $item
  * (Delegated) Implements hook_civicrm_navigationMenu().
  */
 function _donotsendreportemail_civix_navigationMenu(&$nodes) {
-  if (!is_callable(array('CRM_Core_BAO_Navigation', 'fixNavigationMenu'))) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
     _donotsendreportemail_civix_fixNavigationMenu($nodes);
   }
 }
@@ -426,33 +204,4 @@ function _donotsendreportemail_civix_fixNavigationMenuItems(&$nodes, &$maxNavID,
       _donotsendreportemail_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
     }
   }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
- */
-function _donotsendreportemail_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  static $configured = FALSE;
-  if ($configured) {
-    return;
-  }
-  $configured = TRUE;
-
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_entityTypes().
- *
- * Find any *.entityType.php files, merge their content, and return.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
- */
-function _donotsendreportemail_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, []);
 }

--- a/donotsendreportemail.php
+++ b/donotsendreportemail.php
@@ -13,15 +13,6 @@ function donotsendreportemail_civicrm_config(&$config) {
 }
 
 /**
- * Implements hook_civicrm_xmlMenu().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
- */
-function donotsendreportemail_civicrm_xmlMenu(&$files) {
-  _donotsendreportemail_civix_civicrm_xmlMenu($files);
-}
-
-/**
  * Implements hook_civicrm_install().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
@@ -31,107 +22,12 @@ function donotsendreportemail_civicrm_install() {
 }
 
 /**
- * Implements hook_civicrm_postInstall().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
- */
-function donotsendreportemail_civicrm_postInstall() {
-  _donotsendreportemail_civix_civicrm_postInstall();
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
- */
-function donotsendreportemail_civicrm_uninstall() {
-  _donotsendreportemail_civix_civicrm_uninstall();
-}
-
-/**
  * Implements hook_civicrm_enable().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
  */
 function donotsendreportemail_civicrm_enable() {
   _donotsendreportemail_civix_civicrm_enable();
-}
-
-/**
- * Implements hook_civicrm_disable().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
- */
-function donotsendreportemail_civicrm_disable() {
-  _donotsendreportemail_civix_civicrm_disable();
-}
-
-/**
- * Implements hook_civicrm_upgrade().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
- */
-function donotsendreportemail_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  return _donotsendreportemail_civix_civicrm_upgrade($op, $queue);
-}
-
-/**
- * Implements hook_civicrm_managed().
- *
- * Generate a list of entities to create/deactivate/delete when this module
- * is installed, disabled, uninstalled.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
- */
-function donotsendreportemail_civicrm_managed(&$entities) {
-  _donotsendreportemail_civix_civicrm_managed($entities);
-}
-
-/**
- * Implements hook_civicrm_caseTypes().
- *
- * Generate a list of case-types.
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
- */
-function donotsendreportemail_civicrm_caseTypes(&$caseTypes) {
-  _donotsendreportemail_civix_civicrm_caseTypes($caseTypes);
-}
-
-/**
- * Implements hook_civicrm_angularModules().
- *
- * Generate a list of Angular modules.
- *
- * Note: This hook only runs in CiviCRM 4.5+. It may
- * use features only available in v4.6+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
- */
-function donotsendreportemail_civicrm_angularModules(&$angularModules) {
-  _donotsendreportemail_civix_civicrm_angularModules($angularModules);
-}
-
-/**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
- */
-function donotsendreportemail_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _donotsendreportemail_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
- * Implements hook_civicrm_entityTypes().
- *
- * Declare entity types provided by this module.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
- */
-function donotsendreportemail_civicrm_entityTypes(&$entityTypes) {
-  _donotsendreportemail_civix_civicrm_entityTypes($entityTypes);
 }
 
 /**

--- a/info.xml
+++ b/info.xml
@@ -23,5 +23,9 @@
   <comments>This extension aborts sending email when the rows are empty.</comments>
   <civix>
     <namespace>CRM/Donotsendreportemail</namespace>
+    <format>23.02.1</format>
   </civix>
+  <classloader>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
 </extension>

--- a/mixin/polyfill.php
+++ b/mixin/polyfill.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * When deploying on systems that lack mixin support, fake it.
+ *
+ * @mixinFile polyfill.php
+ *
+ * This polyfill does some (persnickity) deduplication, but it doesn't allow upgrades or shipping replacements in core.
+ *
+ * Note: The polyfill.php is designed to be copied into extensions for interoperability. Consequently, this file is
+ * not used 'live' by `civicrm-core`. However, the file does need a canonical home, and it's convenient to keep it
+ * adjacent to the actual mixin files.
+ *
+ * @param string $longName
+ * @param string $shortName
+ * @param string $basePath
+ */
+return function ($longName, $shortName, $basePath) {
+  // Construct imitations of the mixin services. These cannot work as well (e.g. with respect to
+  // number of file-reads, deduping, upgrading)... but they should be OK for a few months while
+  // the mixin services become available.
+
+  // List of active mixins; deduped by version
+  $mixinVers = [];
+  foreach ((array) glob($basePath . '/mixin/*.mixin.php') as $f) {
+    [$name, $ver] = explode('@', substr(basename($f), 0, -10));
+    if (!isset($mixinVers[$name]) || version_compare($ver, $mixinVers[$name], '>')) {
+      $mixinVers[$name] = $ver;
+    }
+  }
+  $mixins = [];
+  foreach ($mixinVers as $name => $ver) {
+    $mixins[] = "$name@$ver";
+  }
+
+  // Imitate CRM_Extension_MixInfo.
+  $mixInfo = new class() {
+
+    /**
+     * @var string
+     */
+    public $longName;
+
+    /**
+     * @var string
+     */
+    public $shortName;
+
+    public $_basePath;
+
+    public function getPath($file = NULL) {
+      return $this->_basePath . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+    }
+
+    public function isActive() {
+      return \CRM_Extension_System::singleton()->getMapper()->isActiveModule($this->shortName);
+    }
+
+  };
+  $mixInfo->longName = $longName;
+  $mixInfo->shortName = $shortName;
+  $mixInfo->_basePath = $basePath;
+
+  // Imitate CRM_Extension_BootCache.
+  $bootCache = new class() {
+
+    public function define($name, $callback) {
+      $envId = \CRM_Core_Config_Runtime::getId();
+      $oldExtCachePath = \Civi::paths()->getPath("[civicrm.compile]/CachedExtLoader.{$envId}.php");
+      $stat = stat($oldExtCachePath);
+      $file = Civi::paths()->getPath('[civicrm.compile]/CachedMixin.' . md5($name . ($stat['mtime'] ?? 0)) . '.php');
+      if (file_exists($file)) {
+        return include $file;
+      }
+      else {
+        $data = $callback();
+        file_put_contents($file, '<' . "?php\nreturn " . var_export($data, 1) . ';');
+        return $data;
+      }
+    }
+
+  };
+
+  // Imitate CRM_Extension_MixinLoader::run()
+  // Parse all live mixins before trying to scan any classes.
+  global $_CIVIX_MIXIN_POLYFILL;
+  foreach ($mixins as $mixin) {
+    // If the exact same mixin is defined by multiple exts, just use the first one.
+    if (!isset($_CIVIX_MIXIN_POLYFILL[$mixin])) {
+      $_CIVIX_MIXIN_POLYFILL[$mixin] = include_once $basePath . '/mixin/' . $mixin . '.mixin.php';
+    }
+  }
+  foreach ($mixins as $mixin) {
+    // If there's trickery about installs/uninstalls/resets, then we may need to register a second time.
+    if (!isset(\Civi::$statics[$longName][$mixin])) {
+      \Civi::$statics[$longName][$mixin] = 1;
+      $func = $_CIVIX_MIXIN_POLYFILL[$mixin];
+      $func($mixInfo, $bootCache);
+    }
+  }
+};


### PR DESCRIPTION
The current civix templates warn about php 7.4 deprecations. To make sure this extension keeps working with php 8, I've upgraded the civix templates with [`civix upgrade`](https://github.com/totten/civix/blob/master/UPGRADE.md).